### PR TITLE
Fix: Wheel Event Propagation Logic Improvement

### DIFF
--- a/src/finbars.js
+++ b/src/finbars.js
@@ -700,8 +700,11 @@ var handlersToBeBound = {
 
     onwheel: function (evt) {
         this.index += evt[this.deltaProp] * this[this.deltaProp + 'Factor'] * this.normal;
-        evt.stopPropagation();
-        evt.preventDefault();
+
+        if (this.range && this.range.min < this.index < this.range.max) {
+            evt.stopPropagation();
+            evt.preventDefault();
+        }
     },
 
     onclick: function (evt) {


### PR DESCRIPTION
Stop wheel event propagation only if scrolling is available or scroller is in between the scrolling range.